### PR TITLE
Link to the actual Uno Library

### DIFF
--- a/devices/TheThingsUno/src/library.properties
+++ b/devices/TheThingsUno/src/library.properties
@@ -5,5 +5,5 @@ maintainer=Johan Stokking <johan@thethingsnetwork.org>
 sentence=An Arduino library for the The Things Uno.
 paragraph=Compatible with any Microchip RN2483 and RN2903 device.
 category=Communication
-url=https://github.com/TheThingsNetwork/sdk
+url=https://github.com/TheThingsNetwork/sdk/tree/master/devices/TheThingsUno
 architectures=*


### PR DESCRIPTION
So users don't have to guess where it is